### PR TITLE
node 18 was failing on this reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "html-minifier": "^4.0.0",
         "minimatch": "^3.0.4",
         "postcss": "^8.3.9",
-        "rollup": "^2.58.0",
+        "rollup": "^3.20.2",
         "sass": "^1.43.2"
       },
       "devDependencies": {
@@ -4442,14 +4442,15 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
-      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -8345,9 +8346,9 @@
       }
     },
     "rollup": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
-      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cagov/11ty-build-system",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cagov/11ty-build-system",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/11ty-build-system",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "license": "MIT",
   "description": "An 11ty plugin to implement @cagov's standard build system for 11ty sites.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "html-minifier": "^4.0.0",
     "minimatch": "^3.0.4",
     "postcss": "^8.3.9",
-    "rollup": "^2.58.0",
+    "rollup": "^3.20.2",
     "sass": "^1.43.2"
   },
   "peerDependencies": {

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const rollup = require('rollup');
-const loadConfigFile = require('rollup/dist/loadConfigFile');
+const loadConfigFile = require('rollup/dist/loadConfigFile.js');
 const chalk = require('chalk');
 const normalize = require('./normalize.js');
 const log = require('./log.js');


### PR DESCRIPTION
This change was a result of me being unable to build sites like drought or innovation when running node18 locally.

Making these updates to the 11ty build system helps the builds for these sites to run locally again:
- upgrade rollup to v3
- change the file reference to the rollup config file to use the file extension

Looking for your feedback on this @xjensen I see you've got this package at a beta version at the moment. 